### PR TITLE
MAINT: pre-process/transform the data before training

### DIFF
--- a/adadamp/_dist.py
+++ b/adadamp/_dist.py
@@ -90,7 +90,6 @@ def gradient(
     """
     # Workaround: Gradients should be cleared when entering this funciton,
     #     but at this moment this behavior is not occuring
-    #  model = deepcopy(model_opt[0])
     model = model_opt[0]
 
     start = time()

--- a/adadamp/_dist.py
+++ b/adadamp/_dist.py
@@ -165,14 +165,14 @@ def _update_model(
     # Make sure the model and optimizer are connected
     init_lr = None
     for g in optimizer.param_groups:
-        init_lr = float(g['lr'])
+        init_lr = float(g["lr"])
 
     optimizer.param_groups = []
     optimizer.add_param_group({"params": list(model.parameters())})
-    
+
     # Re-set learning rate from initial optimizer
     for g in optimizer.param_groups:
-        g['lr'] = init_lr
+        g["lr"] = init_lr
 
     # update model
     optimizer.step()
@@ -313,7 +313,7 @@ class DaskBaseDamper:
             self.cluster.scale(self.n_workers_)
 
         self._meta.update({"n_workers": self.n_workers_})
-        
+
         # compute grads
         grads = self._get_gradients(
             epoch_n_data,
@@ -377,7 +377,7 @@ class DaskBaseDamper:
 
         # Send the model/optimizer to workers
         m = client.scatter(self.module_)
-        
+
         o = client.scatter(self.optimizer_)
         model_opt = client.submit(lambda x, y: (x, y), m, o)
 
@@ -478,7 +478,9 @@ class DaskBaseDamper:
         # Iterate through the dataset in batches
         # TODO: integrate with IterableDataset (this is pretty much already
         # an IterableDataset but without vectorization)
-        idx = self.random_state_.choice(len_dataset, size=min(batch_size, len_dataset), replace=False)
+        idx = self.random_state_.choice(
+            len_dataset, size=min(batch_size, len_dataset), replace=False
+        )
         idx.sort()
         worker_idxs = np.array_split(idx, n_workers)
 
@@ -578,7 +580,7 @@ class DaskClassifierExpiriments(DaskClassifier):
         """
         Sets LR to passed value
         """
-        
+
         if not hasattr(self, "initialized_") or not self.initialized_:
             self.initialize()
 

--- a/adadamp/_dist.py
+++ b/adadamp/_dist.py
@@ -26,13 +26,8 @@ Model = NewType("Model", torch.nn.Module)
 Grads = NewType("Grads", Dict[str, Union[torch.Tensor, float, int]])
 
 
-def _get_model_weights(model):
-    with torch.no_grad():
-        return sum(torch.abs(torch.sum(param)).item() for param in model.parameters())
-
-
-def _weight_sum(model_opt):
-    return _get_model_weights(model_opt[0])
+def _get_model_weights(model: nn.Module) -> float:
+    return sum(torch.abs(torch.sum(param)).item() for param in model.parameters())
 
 
 def _set_random_state(seed: int, device="cuda") -> bool:
@@ -95,7 +90,8 @@ def gradient(
     """
     # Workaround: Gradients should be cleared when entering this funciton,
     #     but at this moment this behavior is not occuring
-    model = deepcopy(model_opt[0])
+    #  model = deepcopy(model_opt[0])
+    model = model_opt[0]
 
     start = time()
 

--- a/adadamp/_dist.py
+++ b/adadamp/_dist.py
@@ -31,7 +31,7 @@ def _get_model_weights(model: nn.Module) -> float:
         s = 0.0
         params = list(model.parameters())
         for k, param in enumerate(reversed(params)):
-            s += torch.sum(torch.abs(param)).item()
+            s += torch.linalg.norm(param).item()
             if k >= 2:
                 break
     return s

--- a/adadamp/_dist.py
+++ b/adadamp/_dist.py
@@ -349,19 +349,22 @@ class DaskBaseDamper:
         return model_opt, bs
 
     def _get_dataset(self, X, y=None) -> TensorDataset:
-        if isinstance(X, Dataset):
+        if isinstance(X, TensorDataset):
+            return X
+        elif isinstance(X, Dataset):
             return self.preprocess(X)
-        if isinstance(X, list):
-            X = np.ndarray(X)
-        if isinstance(X, np.ndarray):
-            X = torch.from_numpy(X)
-        if isinstance(y, list) and len(y):
-            y = np.ndarray(y)
-        if isinstance(y, np.ndarray):
-            y = torch.from_numpy(y)
+        else:
+            if isinstance(X, list):
+                X = np.ndarray(X)
+            if isinstance(X, np.ndarray):
+                X = torch.from_numpy(X)
+            if isinstance(y, list) and len(y):
+                y = np.ndarray(y)
+            if isinstance(y, np.ndarray):
+                y = torch.from_numpy(y)
 
-        args = (X, y) if y is not None else (X,)
-        return TensorDataset(*args)
+            args = (X, y) if y is not None else (X,)
+            return TensorDataset(*args)
 
     def fit(self, X, y=None, **fit_params):
         for epoch in range(self.max_epochs):

--- a/adadamp/_dist.py
+++ b/adadamp/_dist.py
@@ -29,7 +29,8 @@ Grads = NewType("Grads", Dict[str, Union[torch.Tensor, float, int]])
 def _get_model_weights(model: nn.Module) -> float:
     with torch.no_grad():
         s = 0.0
-        for k, param in enumerate(model.parameters()):
+        params = list(model.parameters())
+        for k, param in enumerate(reversed(params)):
             s += torch.sum(torch.abs(param)).item()
             if k >= 2:
                 break
@@ -169,9 +170,9 @@ def _update_model(
 
     new_weights = _get_model_weights(model)
 
-    if np.allclose(old_weights, new_weights):
-        diff = abs(new_weights - old_weights)
-        warn(f"Model appears not to update with diff={diff} > 0")
+    rel_error = abs(new_weights - old_weights) / abs(old_weights)
+    if np.allclose(rel_error, 0):
+        warn(f"Model appears not to update with diff={rel_error}, which is about 0")
 
     return model, optimizer
 

--- a/adadamp/_dist.py
+++ b/adadamp/_dist.py
@@ -110,6 +110,7 @@ def gradient(
     start = time()
 
     # set up data
+    idx.sort()
     _data, _target = train_set[idx]
 
     # split by max bastch size
@@ -231,10 +232,13 @@ class DaskBaseDamper:
         """
         Turn a PyTorch dataset into Torch Tensors.
 
-        This will require a moderate amount of memory. For the MNIST dataset
-        with 60,000 32x32 RGB images, this will consume 234 megabytes of
-        memory. These data are not stored on the training devices (/GPUs), essentially
-        only the transformations are preformed.
+        This will require a moderate amount of memory. For image datasets where
+        each pixel is transformed from uint8 to float32, this will require a
+        factor of 4 more memory. For the popular MNIST and CIFAR datasets, this
+        means 37MB → 150MB and 175MB → 703MB respectively.
+
+        These data are not stored on the training devices (/GPUs), so
+        essentially only the transformations are preformed.
 
         """
         loader = DataLoader(ds, shuffle=False, batch_size=1000)

--- a/tests/test_mnist_dask.py
+++ b/tests/test_mnist_dask.py
@@ -6,6 +6,7 @@ from torchvision import datasets, transforms
 from torch.utils.data import Subset
 import numpy as np
 from distributed.utils_test import gen_cluster
+from dask.distributed import Client
 
 from adadamp import DaskBaseDamper
 
@@ -28,8 +29,7 @@ class Model(nn.Module):
         return output
 
 
-@gen_cluster(client=True)
-def test_mnist_w_dask(c, s, a, b):
+def test_mnist_w_dask(preprocess=False):
     N = 4096
     batch_size = 1024
     net = DaskBaseDamper(
@@ -47,9 +47,20 @@ def test_mnist_w_dask(c, s, a, b):
     )
     dataset = datasets.MNIST("./data", train=True, download=True, transform=transform)
     trimmed = Subset(dataset, np.arange(N).astype(int))
-    #  n, d = 100, 10
-    #  X = np.random.uniform(size=(n, d))
-    #  y = np.random.uniform(size=n)
-    #  _ = net.fit(X, y)
-    _ = net.fit(trimmed)
-    assert True  # sanity check
+    if not preprocess:
+        _ = net.fit(trimmed)
+    else:
+        X, y = net.preprocess(trimmed)
+        _ = net.fit(X, y)
+    assert net.meta_["n_updates"] == 4
+
+
+def _prep():
+    from distributed.protocol import torch
+
+
+if __name__ == "__main__":
+    client = Client()
+    client.run(_prep)
+    for preprocess in [True, False]:
+        test_mnist_w_dask(preprocess=preprocess)

--- a/tests/test_mnist_dask.py
+++ b/tests/test_mnist_dask.py
@@ -50,8 +50,8 @@ def test_mnist_w_dask(preprocess=False):
     if not preprocess:
         _ = net.fit(trimmed)
     else:
-        X, y = net.preprocess(trimmed)
-        _ = net.fit(X, y)
+        ds2 = net.preprocess(trimmed)
+        _ = net.fit(ds2)
     assert net.meta_["n_updates"] == 4
 
 


### PR DESCRIPTION
**What does this PR implement?**
It performs the data transformations before any training begins. If a PyTorch dataset is passed to `.fit`, these transformations will be completed once every epoch (which might be slow). If the user wants to avoid that, they should use this code:

``` python
from adadamp import DaskBaseDamper
from torch.utils.data import transforms
from torchvision import datasets, transforms

net = DaskClassifier(module=Model, ...)

transform = transforms.Compose(
    [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
)
ds = datasets.MNIST("./data", train=True, download=True, transform=transform)
ds2 = net.preprocess(df)
for epoch in range(10):
    net.partial_fit(ds2)
```